### PR TITLE
Remove old celery settings

### DIFF
--- a/cp_ws/settings.py
+++ b/cp_ws/settings.py
@@ -128,12 +128,6 @@ STATIC_URL = '/static/'
 
 STATIC_ROOT = 'static/'
 
-CELERY_ACCEPT_CONTENT = ['application/json']
-
-CELERY_TASK_SERIALIZER = 'json'
-
-CELERY_RESULT_SERIALIZER = 'json'
-
 try:
     import channels
 except ImportError:


### PR DESCRIPTION
JSON has been the default serializer for two major versions, this is not needed in an example project and will only provide confusion